### PR TITLE
Adds declaration and source maps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Secure, audited & minimal implementation of BIP32 hierarchical deterministic (HD) wallets",
 
   "files": [
+    "index.ts",
     "lib/index.js",
     "lib/esm/index.js",
     "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
     "lib/index.js",
     "lib/esm/index.js",
     "lib/index.d.ts",
+    "lib/esm/index.d.ts",
+    "lib/index.js.map",
+    "lib/esm/index.js.map",
+    "lib/index.d.ts.map",
+    "lib/esm/index.d.ts.map",
     "lib/esm/package.json"
   ],
   "main": "lib/index.js",
@@ -17,8 +22,7 @@
     ".": {
       "import": "./lib/esm/index.js",
       "default": "./lib/index.js"
-    },
-    "./index.d.ts": "./lib/index.d.ts"
+    }
   },
   "dependencies": {
     "@noble/hashes": "~1.1.1",

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -10,6 +10,10 @@
     "removeComments": true,
     "preserveConstEnums": true,
     "baseUrl": ".",
+    "sourceMap": true,
+    "inlineSources": true,
+    "declaration": true,
+    "declarationMap": true,
   },
   "include": ["index.ts"],
   "exclude": ["node_modules", "lib"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,10 @@
     "preserveConstEnums": true,
     "resolveJsonModule": true,
     "baseUrl": ".",
+    "sourceMap": true,
+    "inlineSources": true,
+    "declaration": true,
+    "declarationMap": true,
   },
   "include": ["index.ts"],
   "exclude": ["node_modules", "lib"]


### PR DESCRIPTION
Declaration maps are like source maps, but for `.d.ts` files.  It makes it so a user who is looking at the code in an editor can press "goto definition" and be taken to actual source code rather than just seeing the declaration file.

To make this work, the source files do need to be shipped with the package.

Source maps are useful for the same reason, but for distributed JS code.  In an app that uses this library, it may be useful to have a debugger step into these libraries when troubleshooting.