### PR TITLE
Bump noble-curves to ~1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~1.4.0",
+        "@noble/curves": "~1.5.0",
         "@noble/hashes": "~1.4.0",
         "@scure/base": "~1.1.6"
       },
@@ -24,9 +24,10 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
-      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.5.0.tgz",
+      "integrity": "sha512-J5EKamIHnKPyClwVrzmaf5wSdQXgdHcPZIZLu3bwnbeCx8/7NPK5q2ZBWF+5FvYGByjiQQsJYX6jfgB2wDPn3A==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.4.0"
       },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     }
   },
   "dependencies": {
-    "@noble/curves": "~1.4.0",
+    "@noble/curves": "~1.5.0",
     "@noble/hashes": "~1.4.0",
     "@scure/base": "~1.1.6"
   },


### PR DESCRIPTION
This bumps `@noble/curves` to use the latest minor.