### PR TITLE
Prevent deriving unserializable keys of depth > 255

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -221,6 +221,9 @@ export class HDKey {
   }
 
   public deriveChild(index: number): HDKey {
+    if (this.depth == 255) {
+        throw new Error('Cannot derive key with depth > 255');
+    }
     if (!this.pubKey || !this.chainCode) {
       throw new Error('No publicKey or chainCode set');
     }

--- a/index.ts
+++ b/index.ts
@@ -163,6 +163,9 @@ export class HDKey {
     if (!opt || typeof opt !== 'object') {
       throw new Error('HDKey.constructor must not be called directly');
     }
+    if (typeof opt.depth !== 'undefined' && opt.depth >= 256) {
+      throw new Error('HDKey: opt.depth exceeds the serializable value 255');
+    }
     this.versions = opt.versions || BITCOIN_VERSIONS;
     this.depth = opt.depth || 0;
     this.chainCode = opt.chainCode || null;
@@ -221,9 +224,6 @@ export class HDKey {
   }
 
   public deriveChild(index: number): HDKey {
-    if (this.depth >= 255) {
-      throw new Error('Cannot derive key with depth > 255');
-    }
     if (!this.pubKey || !this.chainCode) {
       throw new Error('No publicKey or chainCode set');
     }

--- a/index.ts
+++ b/index.ts
@@ -221,8 +221,8 @@ export class HDKey {
   }
 
   public deriveChild(index: number): HDKey {
-    if (this.depth == 255) {
-        throw new Error('Cannot derive key with depth > 255');
+    if (this.depth >= 255) {
+      throw new Error('Cannot derive key with depth > 255');
     }
     if (!this.pubKey || !this.chainCode) {
       throw new Error('No publicKey or chainCode set');

--- a/test/hdkey.test.js
+++ b/test/hdkey.test.js
@@ -79,7 +79,34 @@ const fixtures = [
     },
 ];
 describe('hdkey', () => {
+    it('Should throw an error when constructing a key of excesive depth', () => {
+      const seed = '000102030405060708090a0b0c0d0e0f';
+      var hdkey = HDKey.fromMasterSeed(hexToBytes(seed));
 
+      const optMaxDepth = {
+        versions: hdkey.versions,
+        chainCode: hdkey.chainCode,
+        // The depth is the maximum 255
+        depth: 255,
+        parentFingerprint: hdkey.fingerprint,
+        index: 0,
+        privateKey: hdkey.privateKey,
+      };
+      // no errors
+      new HDKey(optMaxDepth);
+
+      // Craft whatever key, but with excesive depth
+      const optTooDeep = {
+        versions: hdkey.versions,
+        chainCode: hdkey.chainCode,
+        // The depth is exceeding 255
+        depth: 256,
+        parentFingerprint: hdkey.fingerprint,
+        index: 0,
+        privateKey: hdkey.privateKey,
+      };
+      throws(() => new HDKey(optTooDeep));
+    });
     it('Should throw an error when deriving keys of 256 depth', () => {
       const seed = '000102030405060708090a0b0c0d0e0f';
       var hdkey = HDKey.fromMasterSeed(hexToBytes(seed));

--- a/test/hdkey.test.js
+++ b/test/hdkey.test.js
@@ -79,6 +79,30 @@ const fixtures = [
     },
 ];
 describe('hdkey', () => {
+
+    it('Should throw an error when deriving keys of 256 depth', () => {
+      const seed = '000102030405060708090a0b0c0d0e0f';
+      var hdkey = HDKey.fromMasterSeed(hexToBytes(seed));
+
+      // deriving 255 children should work
+      for (let i = 0; i < 255; i++) {
+          hdkey = hdkey.deriveChild(0);
+      }
+      // deriving one more shall throw an error
+      throws(() => hdkey = hdkey.deriveChild(0));
+    });
+
+    it('Should throw an error when deriving from path of length 256', () => {
+      const seed = '000102030405060708090a0b0c0d0e0f';
+      var hdkey = HDKey.fromMasterSeed(hexToBytes(seed));
+
+      // master key "lives" at 0th level, together with 255
+      // more level its 256, which is still serializable
+      hdkey.derive('m' + '/0'.repeat(255));
+      // but deriving one level deeper fails.
+      throws(() => hdkey.derive('m' + '/0'.repeat(256)));
+    });
+
     it('Should derive private key correctly', () => {
         const seed = 'fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542';
         const hdkey = HDKey.fromMasterSeed(hexToBytes(seed));

--- a/test/hdkey.test.js
+++ b/test/hdkey.test.js
@@ -116,9 +116,8 @@ describe('hdkey', () => {
           hdkey = hdkey.deriveChild(0);
       }
       // deriving one more shall throw an error
-      throws(() => hdkey = hdkey.deriveChild(0));
+      throws(() => hdkey.deriveChild(0));
     });
-
     it('Should throw an error when deriving from path of length 256', () => {
       const seed = '000102030405060708090a0b0c0d0e0f';
       var hdkey = HDKey.fromMasterSeed(hexToBytes(seed));

--- a/test/hdkey.test.js
+++ b/test/hdkey.test.js
@@ -128,7 +128,6 @@ describe('hdkey', () => {
       // but deriving one level deeper fails.
       throws(() => hdkey.derive('m' + '/0'.repeat(256)));
     });
-
     it('Should derive private key correctly', () => {
         const seed = 'fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542';
         const hdkey = HDKey.fromMasterSeed(hexToBytes(seed));


### PR DESCRIPTION
I rarely code in Javascript/Node/Typescript, so this is rather hastily effort to put together example of a fix and test cases. Please, review the code carefully, among other for off-by-one errors int the path lengths, thanks!

This attempts to make the derived keys serializable according to [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#serialization-format). See also https://github.com/bitcoin/bitcoin/issues/32201

Unfortunately, this is in a sense breaking backwards-compatibility, in case someone was deriving _lower_ than 255 depth keys, however, these would get serialized, assuming BIP32 format, incorrectly (the depth would overflow).