### PR TITLE
docs: HARDENED_OFFSET is a top-level export, not an HDKey static

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,16 @@ child.verify(msgHash, sig);
 Note: `chainCode` property is essentially a private part
 of a secret "master" key, it should be guarded from unauthorized access.
 
+`HARDENED_OFFSET` is a top-level export (`0x80000000`), not a property of `HDKey`:
+
+```ts
+import { HARDENED_OFFSET } from '@scure/bip32';
+```
+
 The full API is:
 
 ```ts
 class HDKey {
-  public static HARDENED_OFFSET: number;
   public static fromMasterSeed(seed: Uint8Array, versions: Versions): HDKey;
   public static fromExtendedKey(base58key: string, versions: Versions): HDKey;
   public static fromJSON(json: { xpriv: string }): HDKey;


### PR DESCRIPTION
closes #9

### what

The README's "full API" block lists `HARDENED_OFFSET` as a static on the `HDKey` class:

```ts
class HDKey {
  public static HARDENED_OFFSET: number;
  ...
```

but it is a top-level export (`index.ts`), so `HDKey.HARDENED_OFFSET` is `undefined` at runtime:

```
$ node -e "const {HDKey,HARDENED_OFFSET}=require('@scure/bip32'); console.log(HARDENED_OFFSET, HDKey.HARDENED_OFFSET)"
2147483648 undefined
```

### how

Move `HARDENED_OFFSET` out of the class block and document it as the top-level named import it actually is:

```ts
import { HARDENED_OFFSET } from '@scure/bip32';
```

Docs-only.
